### PR TITLE
Implement logging helper

### DIFF
--- a/packages/helpers/LICENSE.md
+++ b/packages/helpers/LICENSE.md
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright 2023 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/helpers/__tests__/logger.test.ts
+++ b/packages/helpers/__tests__/logger.test.ts
@@ -1,0 +1,397 @@
+import * as core from '@actions/core'
+import {Logger} from '../src/logger'
+import os from 'os'
+
+const logSpy = jest.spyOn(core, 'info')
+const cnSpy = jest.spyOn(process.stdout, 'write')
+const isDebugSpy = jest.spyOn(core, 'isDebug')
+
+const createCounter =
+  (initial = 0) =>
+  () =>
+    initial++
+
+let count = createCounter(1)
+
+describe('logger', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    count = createCounter(1)
+
+    cnSpy.mockImplementation(() => {
+      // uncomment to debug
+      // process.stderr.write('write:' + line + '\n');
+      return false
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should log a message', () => {
+    const logger = new Logger({
+      level: Logger.LOG_LEVELS.INFO,
+      outputs: [new Logger.OUTPUTS.CoreOutput()]
+    })
+
+    logger.info('test')
+
+    logger.startContext('test')
+
+    logger.info('test')
+
+    logger.endContext()
+
+    expect(logSpy).toHaveBeenCalledTimes(2)
+
+    expect(logSpy).toHaveBeenNthCalledWith(count(), 'test')
+    expect(logSpy).toHaveBeenNthCalledWith(count(), '[test] test')
+  })
+
+  it('should log different levels', () => {
+    const logger = new Logger({
+      level: Logger.LOG_LEVELS.INFO,
+      outputs: [new Logger.OUTPUTS.CoreOutput()]
+    })
+
+    logger.error('test')
+    logger.warning('test')
+    logger.notice('test')
+    logger.info('test')
+
+    expect(cnSpy).toHaveBeenCalledTimes(4)
+
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::error::test${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::warning::test${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::notice::test${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `test${os.EOL}`)
+
+    isDebugSpy.mockReturnValue(true)
+
+    logger.debug('test')
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::debug::test${os.EOL}`)
+
+    isDebugSpy.mockReturnValue(false)
+    expect(cnSpy).toHaveBeenCalledTimes(5)
+  })
+
+  it('should not log messages above the log level', () => {
+    const logger = new Logger({
+      level: Logger.LOG_LEVELS.WARNING,
+      outputs: [new Logger.OUTPUTS.CoreOutput()]
+    })
+
+    logger.error('test')
+    logger.warning('test')
+    logger.notice('test')
+    logger.info('test')
+
+    expect(cnSpy).toHaveBeenCalledTimes(2)
+
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::error::test${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::warning::test${os.EOL}`)
+  })
+
+  it('should group messages', () => {
+    const logger = new Logger({
+      level: Logger.LOG_LEVELS.INFO,
+      outputs: [new Logger.OUTPUTS.CoreOutput()]
+    })
+
+    logger.info('outside group')
+    logger.startGroup('group')
+    logger.info('within group')
+    logger.endGroup()
+    logger.info('outside group')
+
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `outside group${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::group::group${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `within group${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::endgroup::${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `outside group${os.EOL}`)
+  })
+
+  it('should group messages without group support', () => {
+    const logger = new Logger({
+      level: Logger.LOG_LEVELS.INFO,
+      outputs: [new Logger.OUTPUTS.CoreOutput(false)]
+    })
+
+    logger.info('outside group')
+    logger.startGroup('group')
+    logger.info('within group')
+    logger.endGroup()
+    logger.info('outside group')
+
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `outside group${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[group] within group${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `outside group${os.EOL}`)
+  })
+
+  it('supports complex grouping', () => {
+    const logger = new Logger({
+      level: Logger.LOG_LEVELS.INFO,
+      outputs: [new Logger.OUTPUTS.CoreOutput()]
+    })
+
+    logger.startGroup('Hello group')
+    logger.info('Hello, world!')
+    logger.endGroup()
+
+    logger.startContext('Outside context')
+    logger.info('Hello, world!')
+
+    logger.startGroup('Group')
+    logger.startContext('Inside context')
+    logger.info('Hello, world!')
+    logger.startContext('Inside context 2')
+    logger.info('Hello, world!')
+    logger.endContext()
+    logger.info('Hello, world!')
+    logger.endGroup()
+
+    logger.info('Hello, world!')
+    logger.endContext()
+    logger.info('Hello, world!')
+
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `::group::Hello group${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `Hello, world!${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::endgroup::${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Outside context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `::group::[Outside context] Group${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Inside context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Inside context] [Inside context 2] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Inside context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::endgroup::${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Outside context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `Hello, world!${os.EOL}`)
+  })
+
+  it('supports locking contexts', () => {
+    const logger = new Logger({
+      level: Logger.LOG_LEVELS.INFO,
+      outputs: [new Logger.OUTPUTS.CoreOutput()]
+    })
+
+    logger.info('Hello, world!')
+
+    logger.withContextSync('Locked context', () => {
+      logger.info('Hello, world!')
+
+      logger.startContext('Not locked context')
+
+      logger.info('Hello, world!')
+
+      // removes second context
+      logger.endContext()
+
+      // has no effect
+      logger.endContext()
+
+      logger.info('Hello, world!')
+
+      logger.withContextSync('Locked context 2', () => {
+        logger.info('Hello, world!')
+      })
+
+      logger.info('Hello, world!')
+    })
+
+    logger.info('Hello, world!')
+
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `Hello, world!${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] [Not locked context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] [Locked context 2] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `Hello, world!${os.EOL}`)
+  })
+
+  it('supports locking contexts in async functions', async () => {
+    const logger = new Logger({
+      level: Logger.LOG_LEVELS.INFO,
+      outputs: [new Logger.OUTPUTS.CoreOutput()]
+    })
+
+    logger.info('Hello, world!')
+
+    await logger.withContext('Locked context', async () => {
+      logger.info('Hello, world!')
+
+      logger.startContext('Not locked context')
+
+      logger.info('Hello, world!')
+
+      // removes second context
+      logger.endContext()
+
+      // has no effect
+      logger.endContext()
+
+      logger.info('Hello, world!')
+
+      await logger.withContext('Locked context 2', () => {
+        logger.info('Hello, world!')
+      })
+
+      logger.info('Hello, world!')
+    })
+
+    logger.withGroupSync('Locked group', () => {
+      logger.info('Message in locked group')
+    })
+
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `Hello, world!${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] [Not locked context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] [Locked context 2] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] Hello, world!${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `::group::Locked group${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `Message in locked group${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::endgroup::${os.EOL}`)
+  })
+
+  it('supports locking groups', async () => {
+    const logger = new Logger({
+      level: Logger.LOG_LEVELS.INFO,
+      outputs: [new Logger.OUTPUTS.CoreOutput()]
+    })
+
+    await logger.withGroup('Locked group', async () => {
+      logger.info('Message in locked group')
+
+      await logger.withContext('Locked context', async () => {
+        logger.info('Message in locked group in locked context')
+
+        await logger.withContext('Locked context 2', () => {
+          logger.info('Message in locked group in locked context 2')
+        })
+
+        // has no effect
+        logger.endContext()
+
+        logger.info('Message in locked group in locked context')
+      })
+
+      // has no effect
+      logger.endGroup()
+
+      logger.info('Message in locked group')
+    })
+
+    logger.info('Message outside locked group')
+
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `::group::Locked group${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `Message in locked group${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] Message in locked group in locked context${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] [Locked context 2] Message in locked group in locked context 2${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[Locked context] Message in locked group in locked context${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `Message in locked group${os.EOL}`
+    )
+    expect(cnSpy).toHaveBeenNthCalledWith(count(), `::endgroup::${os.EOL}`)
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `Message outside locked group${os.EOL}`
+    )
+  })
+
+  it('supports sequential group declaration', () => {
+    const logger = new Logger({
+      level: Logger.LOG_LEVELS.INFO,
+      outputs: [new Logger.OUTPUTS.CoreOutput(false)]
+    })
+
+    logger.startGroup('group 1')
+
+    logger.startContext('context 1')
+
+    logger.startGroup('group 2')
+
+    logger.info('Hello, world!')
+
+    expect(cnSpy).toHaveBeenNthCalledWith(
+      count(),
+      `[group 2] Hello, world!${os.EOL}`
+    )
+  })
+})

--- a/packages/helpers/package-lock.json
+++ b/packages/helpers/package-lock.json
@@ -1,0 +1,72 @@
+{
+  "name": "@actions/helpers",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@actions/helpers",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.10.0",
+        "@actions/exec": "^1.1.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.5.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.1.tgz",
+      "integrity": "sha512-qhrkRMB40bbbLo7gF+0vu+X+UawOvQQqNAA/5Unx774RS8poaOhThDOG6BGmxvAnxhQnDp2BG/ZUm65xZILTpw==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
+      "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==",
+      "dev": true
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  }
+}

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@actions/helpers",
+  "version": "1.0.0",
+  "description": "Helpers for creating actions",
+  "main": "lib/helpers.js",
+  "types": "lib/helpers.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib",
+    "!.DS_Store"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "audit-moderate": "npm install && npm audit --json --audit-level=moderate > audit.json",
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "tsc": "tsc -p tsconfig.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/actions/toolkit.git",
+    "directory": "packages/helpers"
+  },
+  "keywords": [
+    "github",
+    "actions",
+    "helpers"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/actions/toolkit/issues"
+  },
+  "homepage": "https://github.com/actions/toolkit#readme",
+  "devDependencies": {
+    "@types/node": "^20.5.0"
+  },
+  "dependencies": {
+    "@actions/core": "^1.10.0",
+    "@actions/exec": "^1.1.1"
+  }
+}

--- a/packages/helpers/src/helpers.ts
+++ b/packages/helpers/src/helpers.ts
@@ -1,0 +1,1 @@
+import './logger'

--- a/packages/helpers/src/logger/index.ts
+++ b/packages/helpers/src/logger/index.ts
@@ -1,0 +1,1 @@
+export {Logger} from './logger'

--- a/packages/helpers/src/logger/logger.ts
+++ b/packages/helpers/src/logger/logger.ts
@@ -1,0 +1,209 @@
+import {AnnotationProperties} from '@actions/core'
+import {LogContext, LogLevel, Output} from './types'
+import {LOG_LEVELS} from './static'
+import {CoreOutput} from './outputs'
+
+export class Logger {
+  static OUTPUTS = {
+    CoreOutput
+  }
+
+  static LOG_LEVELS = {
+    [LOG_LEVELS[0]]: 0,
+    [LOG_LEVELS[1]]: 1,
+    [LOG_LEVELS[2]]: 2,
+    [LOG_LEVELS[3]]: 3
+  } as const
+
+  private logLevel: LogLevel = Logger.LOG_LEVELS.INFO
+  private contexts: LogContext[] = []
+  private outputs: Output[] = []
+
+  private activeGroup = -1
+  private lockedContexts: number[] = []
+  private groupLocked = false
+
+  constructor(options: {level: LogLevel; outputs: Output[]}) {
+    this.logLevel = options.level
+    this.outputs = options.outputs
+  }
+
+  startContext = (title: string): void => {
+    this.contexts.push({value: title, isGroup: false})
+
+    for (const output of this.outputs) {
+      output.update({
+        contexts: this.contexts,
+        activeGroup: this.activeGroup,
+        type: 'context-start',
+        title
+      })
+    }
+  }
+
+  startGroup = (title: string): void => {
+    if (this.groupLocked) return
+
+    if (this.activeGroup !== -1) {
+      this.contexts.splice(this.activeGroup)
+    }
+
+    this.contexts.push({value: title, isGroup: true})
+    this.activeGroup = this.contexts.length - 1
+
+    for (const output of this.outputs) {
+      output.update({
+        contexts: this.contexts,
+        activeGroup: this.activeGroup,
+        type: 'group-start',
+        title
+      })
+    }
+  }
+
+  endContext = (): void => {
+    const lockedContext = this.lockedContexts.at(-1)
+
+    if (
+      lockedContext !== undefined &&
+      this.contexts.length - 1 <= lockedContext
+    ) {
+      return
+    }
+
+    const latestContext = this.contexts.at(-1)
+
+    if (latestContext === undefined) return
+    if (latestContext.isGroup) return
+
+    this.contexts.pop()
+
+    for (const output of this.outputs) {
+      output.update({
+        contexts: this.contexts,
+        activeGroup: this.activeGroup,
+        type: 'context-end'
+      })
+    }
+  }
+
+  endGroup = (): void => {
+    if (this.groupLocked) return
+    if (this.activeGroup === -1) return
+
+    this.contexts.splice(this.activeGroup)
+    this.activeGroup = -1
+
+    for (const output of this.outputs) {
+      output.update({
+        contexts: this.contexts,
+        activeGroup: this.activeGroup,
+        type: 'group-end'
+      })
+    }
+  }
+
+  async withContext<T>(title: string, fn: () => T): Promise<T> {
+    this.startContext(title)
+    this.lockedContexts.push(this.contexts.length - 1)
+
+    try {
+      return await new Promise(resolve => resolve(fn()))
+    } finally {
+      this.contexts.splice((this.lockedContexts.pop() ?? -1) + 1)
+      this.endContext()
+    }
+  }
+
+  withContextSync<T>(title: string, fn: () => T): T {
+    this.startContext(title)
+    this.lockedContexts.push(this.contexts.length - 1)
+
+    try {
+      return fn()
+    } finally {
+      this.contexts.splice((this.lockedContexts.pop() ?? -1) + 1)
+      this.endContext()
+    }
+  }
+
+  async withGroup<T>(title: string, fn: () => T): Promise<T> {
+    if (this.groupLocked) return await new Promise(() => fn())
+
+    this.startGroup(title)
+    this.groupLocked = true
+
+    try {
+      return await new Promise(resolve => resolve(fn()))
+    } finally {
+      this.groupLocked = false
+      this.endGroup()
+    }
+  }
+
+  withGroupSync<T>(title: string, fn: () => T): T {
+    if (this.groupLocked) return fn()
+
+    this.startGroup(title)
+    this.groupLocked = true
+
+    try {
+      return fn()
+    } finally {
+      this.groupLocked = false
+      this.endGroup()
+    }
+  }
+
+  log = (
+    level: LogLevel,
+    message: string | Error,
+    properties?: AnnotationProperties
+  ): void => {
+    if (level > this.logLevel) return
+
+    for (const output of this.outputs) {
+      output.message({
+        contexts: this.contexts,
+        activeGroup: this.activeGroup,
+        level,
+        payload: message,
+        properties
+      })
+    }
+  }
+
+  debug = (message: string): void => {
+    for (const output of this.outputs) {
+      output.message({
+        contexts: this.contexts,
+        activeGroup: this.activeGroup,
+        level: 0,
+        payload: message,
+        isDebug: true
+      })
+    }
+  }
+
+  error = (
+    message: string | Error,
+    properties?: AnnotationProperties
+  ): void => {
+    this.log(Logger.LOG_LEVELS.ERROR, message, properties)
+  }
+
+  warning = (
+    message: string | Error,
+    properties?: AnnotationProperties
+  ): void => {
+    this.log(Logger.LOG_LEVELS.WARNING, message, properties)
+  }
+
+  notice = (message: string): void => {
+    this.log(Logger.LOG_LEVELS.NOTICE, message)
+  }
+
+  info = (message: string): void => {
+    this.log(Logger.LOG_LEVELS.INFO, message)
+  }
+}

--- a/packages/helpers/src/logger/outputs.ts
+++ b/packages/helpers/src/logger/outputs.ts
@@ -1,0 +1,84 @@
+import * as core from '@actions/core'
+import {Output} from './types'
+import {Logger} from './logger'
+
+export class CoreOutput implements Output {
+  constructor(private enableGrouping = true) {}
+
+  message: Output['message'] = ({
+    contexts,
+    activeGroup,
+    level,
+    payload,
+    properties,
+    isDebug
+  }) => {
+    let prefix = ''
+
+    if (this.enableGrouping) {
+      for (let i = activeGroup + 1; i < contexts.length; i++) {
+        prefix += `[${contexts[i].value.toString()}] `
+      }
+    } else {
+      for (const context of contexts) {
+        prefix += `[${context.value.toString()}] `
+      }
+    }
+
+    const output = `${prefix}${payload.toString()}`.trim()
+
+    if (isDebug) {
+      core.debug(output)
+
+      return
+    }
+
+    if (level === Logger.LOG_LEVELS.INFO) {
+      core.info(output)
+
+      return
+    }
+
+    if (level === Logger.LOG_LEVELS.NOTICE) {
+      core.notice(output)
+
+      return
+    }
+
+    if (level === Logger.LOG_LEVELS.WARNING) {
+      core.warning(output, properties)
+
+      return
+    }
+
+    if (level === Logger.LOG_LEVELS.ERROR) {
+      core.error(output, properties)
+
+      return
+    }
+  }
+
+  update: Output['update'] = ({contexts, type, title}) => {
+    if (type === 'group-start' && this.enableGrouping) {
+      let prefix = ''
+
+      for (const context of contexts) {
+        if (context.isGroup) {
+          break
+        }
+
+        prefix += `[${context.value.toString()}] `
+      }
+
+      core.startGroup((prefix + (title ?? '')).trim())
+
+      return
+    }
+
+    if (type === 'group-end' && this.enableGrouping) {
+      core.endGroup()
+
+      return
+    }
+  }
+}

--- a/packages/helpers/src/logger/static.ts
+++ b/packages/helpers/src/logger/static.ts
@@ -1,0 +1,1 @@
+export const LOG_LEVELS = ['ERROR', 'WARNING', 'NOTICE', 'INFO'] as const

--- a/packages/helpers/src/logger/types.ts
+++ b/packages/helpers/src/logger/types.ts
@@ -1,0 +1,26 @@
+import {AnnotationProperties} from '@actions/core'
+
+export type LogLevel = 0 | 1 | 2 | 3
+
+export type LogContext = {
+  value: string | Error
+  isGroup: boolean
+}
+
+export interface Output {
+  message: (messageData: {
+    contexts: LogContext[]
+    activeGroup: number
+    level: LogLevel
+    payload: string | Error
+    properties?: AnnotationProperties
+    isDebug?: boolean
+  }) => void
+
+  update: (updateData: {
+    contexts: LogContext[]
+    activeGroup: number
+    type: 'context-start' | 'group-start' | 'context-end' | 'group-end'
+    title?: string
+  }) => void
+}

--- a/packages/helpers/tsconfig.json
+++ b/packages/helpers/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./lib",
+    "declaration": true,
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src"
+  ]
+}


### PR DESCRIPTION
### Helper utility for better logging

#### Overview
This utility introduces following features:

1. Log contexts - allow to define custom contexts which would be displayed before any log. Useful for outlining different sections of logs and clarifying the which context the log is related to
2. Log levels - allow to define different logging level for logging instance and toggle between silent and verbose logging modes (as well as anything in-between)
3. Log outputs - allows to define custom outputs for logging instance with specialized adapter modules

#### Usage
##### Initializing logger instance
```typescript
    const logger = new Logger({
     // define logging level: how verbose logging would be of 0-3 values
      level: Logger.LOG_LEVELS.INFO,
     // provide one or multiple output adapters: where logs would be outputted
      outputs: [new Logger.OUTPUTS.CoreOutput()]
    })
```

##### Basic logging - behavior is equivalent to `core` module
```typescript
   /** These methods rely on logging levels **/
   
   // level >= 0
    logger.error('test')
    
    // level >= 1
    logger.warning('test')
    
    // level >= 2
    logger.notice('test')
    
    // level >= 3
    logger.info('test')
    
    /**
      debug does not rely on logging level
      is turned on/off with RUNNER_DEBUG
      environment variable, just like in core module      
     **/
    
    logger.debug('test')
```

##### Grouping (collapsable groups supported by github actions)

Just like in core module collapsable groups can be used by invoking methods `startGroup` and `endGroup`, everything in-between will be placed in collapsable group. Behavior is also the same as in core module: declaring new group without explicitly closing first one will close previous group implicitly and start a new one, invoking `endGroup` when no group is active will result in no effect.

```typescript
    logger.info('outside group')
    logger.startGroup('group')
    logger.info('within group')
    logger.endGroup()
    logger.info('outside group')
```

Additional features for better readability in environments where collapsable groups are not supported.  

Core addapter accepts one parameter which indicates whether groups are supported.
```typescript
    const logger = new Logger({
      level: Logger.LOG_LEVELS.INFO,
      outputs: [new Logger.OUTPUTS.CoreOutput(false)]
    })
```

If not, instead of outputting commands, messages will be displayed with title of a group in parentheses:
```typescript
    // enableGrouping = true (default)
    logger.info('outside group') // -> outside group
    logger.startGroup('group') // -> ::group::group
    logger.info('within group') // -> within group
    logger.endGroup() // -> ::endgroup::
    logger.info('outside group') // -> outside group
    
    // enableGrouping = false
    logger.info('outside group') // -> outside group
    logger.startGroup('group') // ->
    logger.info('within group') // -> [group] within group
    logger.endGroup() // ->
    logger.info('outside group') outside group
  ```
  
  ##### Contexts
  
Contexts allow to write additional information in [parenthesis] before main logging message to help navigating through logs. Contexts are used much the same as groups:
```typescript
    logger.startContext('Context 1')
    logger.info('Hello, world!') // -> [Context 1] Hello, world!
    // Unlike groups contexts can be stacked within each other
    logger.startContext('Context 2')
    logger.info('Hello, world!') // -> [Context 1] [Context 2] Hello, world!
    logger.endContext()
    logger.info('Hello, world!') // -> [Context 1] Hello, world!
    logger.endContext()
```

Contexts are heirarchically lower the groups. Therefore, if one or more contexts are defined within the group, they will stop being active as soon as group is closed:
```typescript
    logger.startGroup('Some group') // -> ::group::Some group
    logger.startContext('Context 1')
    logger.info('Hello, world!') // -> [Context 1] Hello, world!
    logger.startContext('Context 2')
    logger.info('Hello, world!') // -> [Context 1] [Context 2] Hello, world!
    // Removes contexts as well
    logger.endGroup()
    logger.info('Hello, world!') // -> Hello, world!
```

If context was declared outside of a group, the group title will inherit prefixes and all messages within group will appear without context as they now all would be under the same title:
```typescript
    logger.startContext('Context 1')
    logger.startGroup('Some group') // -> ::group::[Context 1] Some group
    logger.info('Hello, world!') // -> Hello, world!
    logger.startContext('Context 2')
    logger.info('Hello, world!') // -> [Context 2] Hello, world!
    // Removes only 'Context 2' as it was declared within group
    logger.endGroup() // ::endgroup::
    logger.info('Hello, world!') // -> [Context 1] Hello, world!
```

##### Wrapper functions for contexts and groups
`withGroup`
`withGroupSync`
`withContext`
`withContextSync`

Are serving the purpose of automating invocation of closing function. sync and async versions have the same semantics and api and serve for wrapping synchronous and asynchronous code respectively.

```typescript
logger.info('foo') // -> foo
logger.withContextSync('bar', () => {
  logger.info('foo') // -> [bar] foo
})
logger.info('foo') // -> foo
```

They also do not allow to go lower than context or group defined by them in order to keep behavior consistent and avoid unnecessary debugging

```typescript
logger.info('foo') // -> foo
logger.withContextSync('bar', () => {
  logger.startContext('baz')
  logger.info('foo') // -> [baz] [bar] foo
  logger.endContext()
  logger.info('foo') // -> [bar] foo
  logger.endContext() // has no effect
  logger.info('foo') // -> [bar] foo
})
logger.info('foo') // -> foo
```

Therefore, contexts defined by wrapper-functions would not allow to remove that particular context within the same function and groups defined by wrapper-functions would not allow to end group defined within that same function as well as switching to a different group.